### PR TITLE
Fix PHP and xdebug version mismatch error

### DIFF
--- a/infra/docker/php/Dockerfile
+++ b/infra/docker/php/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
     docker-php-ext-install intl pdo_mysql zip bcmath && \
     composer config -g process-timeout 3600 && \
     composer config -g repos.packagist composer https://packagist.org && \
-    pecl install xdebug && \
+    pecl install xdebug-3.1.6 && \
     docker-php-ext-enable xdebug
 
 COPY ./infra/docker/php/php-fpm.d/zzz-www.conf /usr/local/etc/php-fpm.d/zzz-www.conf


### PR DESCRIPTION
説明
PHPのバージョンとxdebugのバージョンに互換性がない問題を解決した。
- xdebugのバージョンをPHPのバージョンに合わせて更新。
- Dockerコンテナが起動することを確認した。